### PR TITLE
Refactor to Riverpod state management with comprehensive documentation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,30 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
 
+/// ============================================================
+/// MAIN ENTRY POINT - RIVERPOD SETUP
+/// ============================================================
+///
+/// WHAT IS RIVERPOD?
+/// Riverpod is a state management solution for Flutter that's:
+/// - Type-safe (catches errors at compile time)
+/// - Testable (easy to write unit tests)
+/// - No BuildContext needed (can use anywhere)
+/// - Composable (providers can depend on other providers)
+///
+/// WHY WRAP WITH ProviderScope?
+/// - ProviderScope is the root widget that enables Riverpod
+/// - ALL providers in your app must be under a ProviderScope
+/// - Think of it as the "container" that holds all your state
+///
+/// Without ProviderScope, Riverpod won't work!
 void main() {
-  runApp(const App());
+  runApp(
+    // ProviderScope enables Riverpod for the entire app
+    const ProviderScope(
+      child: App(),
+    ),
+  );
 }

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,0 +1,397 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/auth_service.dart';
+import '../models/user_model.dart';
+import '../utils/local_storage/storage_utility.dart';
+import '../utils/logging/logger.dart';
+
+/// ============================================================
+/// RIVERPOD STATE MANAGEMENT - AUTHENTICATION
+/// ============================================================
+///
+/// WHAT IS RIVERPOD?
+/// Riverpod is a modern, robust state management solution that:
+/// - Eliminates runtime errors (compile-time safety)
+/// - Works without BuildContext
+/// - Easy to test
+/// - Allows providers to depend on other providers
+///
+/// KEY RIVERPOD CONCEPTS:
+///
+/// 1. PROVIDER - Creates and manages state
+/// 2. STATENOTIFIER - Class that manages mutable state
+/// 3. REF - Object that lets you interact with other providers
+/// 4. CONSUMER - Widget that listens to providers
+///
+/// ============================================================
+
+// ============================================================
+// 1. LOGIN STATE CLASS
+// ============================================================
+//
+/// This class represents the current state of the login screen
+///
+/// WHY A SEPARATE STATE CLASS?
+/// - In Riverpod, we separate STATE (data) from LOGIC (notifier)
+/// - Makes it easy to know exactly what data the UI needs
+/// - Makes state immutable (can't accidentally modify it)
+///
+/// Think of this as a snapshot of the login screen at any moment:
+/// - Is it loading?
+/// - Is there an error?
+/// - Is the user logged in?
+class LoginState {
+  final bool isLoading;
+  final String? errorMessage;
+  final UserModel? user;
+  final bool hidePassword;
+
+  const LoginState({
+    this.isLoading = false,
+    this.errorMessage,
+    this.user,
+    this.hidePassword = true,
+  });
+
+  /// COPY WITH METHOD
+  /// Since state is immutable, we create a new state with updated values
+  ///
+  /// Example:
+  /// ```
+  /// final newState = currentState.copyWith(isLoading: true);
+  /// ```
+  LoginState copyWith({
+    bool? isLoading,
+    String? errorMessage,
+    UserModel? user,
+    bool? hidePassword,
+    bool clearError = false,
+  }) {
+    return LoginState(
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: clearError ? null : (errorMessage ?? this.errorMessage),
+      user: user ?? this.user,
+      hidePassword: hidePassword ?? this.hidePassword,
+    );
+  }
+}
+
+// ============================================================
+// 2. LOGIN NOTIFIER (The "Brain" of Login)
+// ============================================================
+//
+/// StateNotifier manages the state and contains all the business logic
+///
+/// WHAT IS StateNotifier?
+/// - It's a class that holds and modifies state
+/// - Similar to GetX Controller, but more structured
+/// - State can only be changed inside the notifier (immutable from outside)
+///
+/// WHY USE StateNotifier?
+/// - Clear separation: UI reads state, Notifier changes state
+/// - Predictable: State only changes through defined methods
+/// - Testable: Easy to test without UI
+class LoginNotifier extends StateNotifier<LoginState> {
+  // Constructor - initializes with default state
+  LoginNotifier(this._authService, this._localStorage)
+      : super(const LoginState()) {
+    // Check if user is already logged in when notifier is created
+    checkLoginStatus();
+  }
+
+  // Dependencies (injected via providers)
+  final AuthService _authService;
+  final TLocalStorage _localStorage;
+
+  // ============================================================
+  // FORM CONTROLLERS
+  // ============================================================
+  // Note: TextEditingControllers are not part of state in Riverpod
+  // They're created in the widget and passed to methods
+  // This is because controllers have lifecycle (need to be disposed)
+
+  // ============================================================
+  // MAIN LOGIN METHOD
+  // ============================================================
+  ///
+  /// This is called when user taps the "Login" button
+  ///
+  /// RIVERPOD PATTERN:
+  /// 1. Update state to show loading
+  /// 2. Call service (async operation)
+  /// 3. Update state with result (success or error)
+  /// 4. Return result so UI can react (navigate, show message)
+  ///
+  /// Notice: We don't navigate or show snackbars here!
+  /// The UI will do that based on the return value
+  /// This keeps the business logic separate from UI logic
+  Future<bool> login({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      TLoggerHelper.info('Starting login process for: $email');
+
+      // STEP 1: Update state to show loading
+      // This will trigger UI to show loading spinner
+      state = state.copyWith(isLoading: true, clearError: true);
+
+      // STEP 2: Call the API
+      final response = await _authService.login(
+        email: email.trim(),
+        password: password,
+      );
+
+      // STEP 3: Handle the response
+      if (response.success && response.data != null) {
+        // LOGIN SUCCESS! 🎉
+
+        TLoggerHelper.info('Login successful');
+
+        // Save user data to local storage
+        await _saveUserData(response.data!);
+
+        // Update state with user data and stop loading
+        state = state.copyWith(
+          isLoading: false,
+          user: response.data,
+          clearError: true,
+        );
+
+        // Return true to indicate success
+        // The UI will handle navigation
+        return true;
+      } else {
+        // LOGIN FAILED ❌
+
+        TLoggerHelper.warning('Login failed: ${response.error}');
+
+        // Update state with error message and stop loading
+        state = state.copyWith(
+          isLoading: false,
+          errorMessage: response.error ?? 'Login failed',
+        );
+
+        // Return false to indicate failure
+        return false;
+      }
+    } catch (e) {
+      // UNEXPECTED ERROR
+
+      TLoggerHelper.error('Login error: $e');
+
+      // Update state with error and stop loading
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: 'An unexpected error occurred. Please try again.',
+      );
+
+      return false;
+    }
+  }
+
+  // ============================================================
+  // HELPER METHODS
+  // ============================================================
+
+  /// Toggle password visibility
+  /// Called when user taps the eye icon
+  void togglePasswordVisibility() {
+    state = state.copyWith(hidePassword: !state.hidePassword);
+  }
+
+  /// Clear error message
+  /// Useful when user starts typing again
+  void clearError() {
+    if (state.errorMessage != null) {
+      state = state.copyWith(clearError: true);
+    }
+  }
+
+  /// Save user data to local storage
+  /// Keeps user logged in even after closing the app
+  Future<void> _saveUserData(UserModel user) async {
+    try {
+      await _localStorage.saveData('user', user.toJson());
+      // In real app, also save token:
+      // await _localStorage.saveData('auth_token', token);
+      TLoggerHelper.info('User data saved to local storage');
+    } catch (e) {
+      TLoggerHelper.error('Error saving user data: $e');
+    }
+  }
+
+  /// Check if user is already logged in
+  /// Called when app starts
+  Future<void> checkLoginStatus() async {
+    try {
+      final userData = _localStorage.readData<Map<String, dynamic>>('user');
+
+      if (userData != null) {
+        final user = UserModel.fromJson(userData);
+        state = state.copyWith(user: user);
+        TLoggerHelper.info('User already logged in: ${user.username}');
+      } else {
+        TLoggerHelper.info('No logged-in user found');
+      }
+    } catch (e) {
+      TLoggerHelper.error('Error checking login status: $e');
+    }
+  }
+
+  /// Logout user
+  /// Clears all stored data and resets state
+  Future<void> logout() async {
+    try {
+      state = state.copyWith(isLoading: true);
+
+      // Clear local storage
+      await _localStorage.removeData('user');
+      await _localStorage.removeData('auth_token');
+
+      // Reset state
+      state = const LoginState();
+
+      TLoggerHelper.info('User logged out successfully');
+    } catch (e) {
+      TLoggerHelper.error('Logout error: $e');
+      state = state.copyWith(isLoading: false);
+    }
+  }
+}
+
+// ============================================================
+// 3. PROVIDERS (How to access state in your app)
+// ============================================================
+//
+/// WHAT IS A PROVIDER?
+/// A provider is like a global variable that:
+/// - Can be accessed from anywhere in the app
+/// - Automatically rebuilds widgets when it changes
+/// - Is type-safe and compile-time checked
+/// - Can depend on other providers
+///
+/// PROVIDER TYPES IN RIVERPOD:
+/// - Provider: For objects that never change
+/// - StateProvider: For simple state (like a counter)
+/// - StateNotifierProvider: For complex state with logic
+/// - FutureProvider: For async operations that run once
+/// - StreamProvider: For streams of data
+
+/// Auth Service Provider
+/// Provides a single instance of AuthService to the app
+///
+/// WHY MAKE THIS A PROVIDER?
+/// - Single instance (singleton pattern)
+/// - Can be easily mocked for testing
+/// - Can be accessed from any provider
+final authServiceProvider = Provider<AuthService>((ref) {
+  return AuthService();
+});
+
+/// Local Storage Provider
+/// Provides a single instance of TLocalStorage
+final localStorageProvider = Provider<TLocalStorage>((ref) {
+  return TLocalStorage();
+});
+
+/// Login State Provider
+/// This is the main provider that manages login state
+///
+/// HOW TO USE IN YOUR WIDGETS:
+/// ```dart
+/// // Read the current state
+/// final loginState = ref.watch(loginStateProvider);
+///
+/// // Call a method on the notifier
+/// ref.read(loginStateProvider.notifier).login(email, password);
+/// ```
+///
+/// StateNotifierProvider has TWO parts:
+/// 1. loginStateProvider - gives you the STATE (LoginState)
+/// 2. loginStateProvider.notifier - gives you the NOTIFIER (LoginNotifier)
+///
+/// PATTERN:
+/// - Use ref.watch() to READ state and REBUILD when it changes
+/// - Use ref.read() to CALL methods without rebuilding
+final loginStateProvider =
+    StateNotifierProvider<LoginNotifier, LoginState>((ref) {
+  // Get dependencies from other providers
+  final authService = ref.watch(authServiceProvider);
+  final localStorage = ref.watch(localStorageProvider);
+
+  // Create and return the notifier with dependencies
+  return LoginNotifier(authService, localStorage);
+});
+
+// ============================================================
+// 4. HELPER PROVIDERS (Optional but useful)
+// ============================================================
+
+/// Current User Provider
+/// A simple way to check if user is logged in
+///
+/// Example usage:
+/// ```dart
+/// final user = ref.watch(currentUserProvider);
+/// if (user != null) {
+///   // User is logged in
+/// }
+/// ```
+final currentUserProvider = Provider<UserModel?>((ref) {
+  return ref.watch(loginStateProvider).user;
+});
+
+/// Is Loading Provider
+/// A simple way to check if login is in progress
+///
+/// Example usage:
+/// ```dart
+/// final isLoading = ref.watch(isLoadingProvider);
+/// if (isLoading) {
+///   return CircularProgressIndicator();
+/// }
+/// ```
+final isLoadingProvider = Provider<bool>((ref) {
+  return ref.watch(loginStateProvider).isLoading;
+});
+
+// ============================================================
+// KEY DIFFERENCES: RIVERPOD vs GETX
+// ============================================================
+//
+// GetX:
+// - controller.isLoading.value = true;
+// - Obx(() => widget)
+// - Get.put(Controller())
+//
+// Riverpod:
+// - state = state.copyWith(isLoading: true);
+// - ref.watch(provider)
+// - Providers are automatically managed
+//
+// ============================================================
+// RIVERPOD ADVANTAGES
+// ============================================================
+//
+// 1. COMPILE-TIME SAFETY
+//    - Typos and errors caught before running
+//    - Better IDE autocomplete
+//
+// 2. NO CONTEXT NEEDED
+//    - Can use providers anywhere, not just in widgets
+//    - Can call providers from other providers
+//
+// 3. TESTABILITY
+//    - Easy to override providers in tests
+//    - No need to mock complex controller initialization
+//
+// 4. IMMUTABLE STATE
+//    - State can only change through defined methods
+//    - Easier to debug and reason about
+//
+// 5. BETTER DEVTOOLS
+//    - Riverpod has excellent debugging tools
+//    - Can see all providers and their state
+//
+// ============================================================

--- a/lib/screens/features/login/login_screen.dart
+++ b/lib/screens/features/login/login_screen.dart
@@ -4,36 +4,178 @@ import 'package:BillPoint/utils/constants/sizes.dart';
 import 'package:BillPoint/utils/constants/text_strings.dart';
 import 'package:BillPoint/utils/helpers/helper_functions.dart';
 import 'package:BillPoint/utils/validators/validation.dart';
-import 'package:BillPoint/controllers/login_controller.dart';
+import 'package:BillPoint/providers/auth_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get/get.dart';
 import 'package:iconsax/iconsax.dart';
 
 /// ============================================================
-/// LOGIN SCREEN WITH API INTEGRATION
+/// LOGIN SCREEN WITH RIVERPOD STATE MANAGEMENT
 /// ============================================================
 ///
-/// This is an example of how to connect your UI to a controller
-/// and integrate with an API
+/// This is a complete example of API integration using Riverpod
 ///
-/// Key concepts demonstrated:
-/// 1. GetX controller initialization with Get.put()
-/// 2. Using controller's TextEditingControllers for inputs
-/// 3. Reactive UI with Obx() widget
-/// 4. Loading states
-/// 5. Form validation
-/// 6. Password visibility toggle
+/// KEY RIVERPOD CONCEPTS DEMONSTRATED:
+///
+/// 1. ConsumerStatefulWidget - Like StatefulWidget but with Riverpod
+/// 2. ref.watch() - Listens to provider changes and rebuilds UI
+/// 3. ref.read() - Reads provider without listening (for one-time calls)
+/// 4. WidgetRef - Object that gives access to providers
+///
+/// ============================================================
+/// RIVERPOD WIDGET TYPES:
+/// ============================================================
+///
+/// 1. ConsumerWidget (Stateless + Riverpod)
+///    - Use when you don't need local state or lifecycle
+///    - Like StatelessWidget but has access to ref
+///
+/// 2. ConsumerStatefulWidget (Stateful + Riverpod)
+///    - Use when you need local state (like TextEditingControllers)
+///    - Like StatefulWidget but has access to ref
+///
+/// 3. Consumer (Just a widget)
+///    - Use to wrap specific parts of widget tree
+///    - Useful when only part of widget needs to rebuild
+///
+/// We use ConsumerStatefulWidget here because we need:
+/// - TextEditingControllers (local state)
+/// - Lifecycle methods (dispose controllers)
+/// - Access to Riverpod providers (ref)
+///
+/// ============================================================
 
-class LoginScreen extends StatelessWidget {
+class LoginScreen extends ConsumerStatefulWidget {
   const LoginScreen({super.key});
+
+  @override
+  ConsumerState<LoginScreen> createState() => _LoginScreenState();
+}
+
+/// ============================================================
+/// CONSUMER STATE - Widget State with Riverpod Access
+/// ============================================================
+///
+/// Notice: ConsumerState<LoginScreen> instead of State<LoginScreen>
+///
+/// This gives us access to 'ref' which lets us:
+/// - ref.watch(provider) - Listen to provider and rebuild when it changes
+/// - ref.read(provider) - Read provider once without listening
+/// - ref.listen(provider, callback) - Run side effects when provider changes
+///
+class _LoginScreenState extends ConsumerState<LoginScreen> {
+  // ============================================================
+  // LOCAL STATE (Widget-specific, not in Riverpod)
+  // ============================================================
+  //
+  // TextEditingControllers are local to the widget because:
+  // - They need to be disposed when widget is destroyed
+  // - They're UI-specific (not business logic)
+  // - Each TextField needs its own controller
+  //
+  // RULE: If it has a lifecycle (dispose), keep it in widget state
+
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    // IMPORTANT: Always dispose controllers to prevent memory leaks
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  // ============================================================
+  // LOGIN HANDLER
+  // ============================================================
+  //
+  /// This method handles the login button press
+  ///
+  /// RIVERPOD PATTERN:
+  /// 1. Validate form
+  /// 2. Call notifier method using ref.read()
+  /// 3. Handle result (navigate, show message)
+  ///
+  /// WHY ref.read()?
+  /// - We're CALLING a method, not listening to state
+  /// - ref.read() doesn't cause rebuilds
+  /// - Use .notifier to access the LoginNotifier methods
+  Future<void> _handleLogin() async {
+    // STEP 1: Validate form
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    // STEP 2: Call login method from provider
+    // ref.read() gives us one-time access to the provider
+    // .notifier gives us access to the LoginNotifier methods
+    final success = await ref.read(loginStateProvider.notifier).login(
+          email: _emailController.text,
+          password: _passwordController.text,
+        );
+
+    // STEP 3: Handle result
+    // Only navigate/show messages if the widget is still mounted
+    if (!mounted) return;
+
+    if (success) {
+      // SUCCESS! Show success message
+      Get.snackbar(
+        'Success',
+        'Login successful',
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.green,
+        colorText: Colors.white,
+        duration: const Duration(seconds: 2),
+      );
+
+      // Navigate to home screen
+      // Note: We still use GetX for navigation (Riverpod doesn't handle navigation)
+      Get.offAllNamed('/home');
+
+      // Clear form fields
+      _emailController.clear();
+      _passwordController.clear();
+    } else {
+      // FAILURE! Error message is already in state
+      // UI will show it automatically because ref.watch() is listening
+      // But we can also show a snackbar
+      final errorMessage = ref.read(loginStateProvider).errorMessage;
+      Get.snackbar(
+        'Login Failed',
+        errorMessage ?? 'Please check your credentials',
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Colors.red,
+        colorText: Colors.white,
+        duration: const Duration(seconds: 3),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // ============================================================
-    // STEP 1: Initialize the controller
+    // WATCHING PROVIDERS
     // ============================================================
-    // Get.put() creates an instance of LoginController and makes it available
-    // throughout this screen. You can access it anywhere with Get.find<LoginController>()
-    final controller = Get.put(LoginController());
+    //
+    /// ref.watch() subscribes to provider changes
+    /// When the provider's state changes, this widget rebuilds
+    ///
+    /// PERFORMANCE TIP:
+    /// - Only watch what you need
+    /// - Can watch specific parts: ref.watch(provider.select((s) => s.isLoading))
+    /// - Or watch the whole state and access properties
+    ///
+    /// We watch the entire loginState here because multiple parts of UI
+    /// need different pieces of state
+
+    // Watch the login state
+    // When state changes, this build method runs again
+    final loginState = ref.watch(loginStateProvider);
+
     final dark = THelperFunctions.isDarkMode(context);
 
     return Scaffold(
@@ -71,22 +213,26 @@ class LoginScreen extends StatelessWidget {
                 flex: 2,
               ),
               // ============================================================
-              // STEP 2: Wrap form with formKey for validation
+              // FORM WITH VALIDATION
               // ============================================================
               Form(
-                key: controller.formKey, // This enables form validation
+                key: _formKey,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
                     // ============================================================
                     // EMAIL FIELD
                     // ============================================================
-                    // Using TextFormField instead of TextField to enable validation
                     TextFormField(
-                      controller: controller.emailController, // Controller from LoginController
+                      controller: _emailController,
                       keyboardType: TextInputType.emailAddress,
-                      // Validation happens here when form.validate() is called
                       validator: (value) => TValidator.validateEmail(value),
+                      // Clear error when user starts typing
+                      onChanged: (value) {
+                        if (loginState.errorMessage != null) {
+                          ref.read(loginStateProvider.notifier).clearError();
+                        }
+                      },
                       decoration: InputDecoration(
                         focusedBorder: OutlineInputBorder(
                           borderSide: BorderSide(
@@ -105,33 +251,41 @@ class LoginScreen extends StatelessWidget {
                     // ============================================================
                     // PASSWORD FIELD WITH VISIBILITY TOGGLE
                     // ============================================================
-                    // Obx() makes this widget reactive to controller.hidePassword changes
-                    Obx(
-                      () => TextFormField(
-                        controller: controller.passwordController,
-                        // hidePassword is reactive - when it changes, UI rebuilds
-                        obscureText: controller.hidePassword.value,
-                        validator: (value) => TValidator.validatePassword(value),
-                        decoration: InputDecoration(
-                          focusedBorder: OutlineInputBorder(
-                            borderSide: BorderSide(
-                              color: dark ? TColors.light : TColors.darkGrey,
-                            ),
+                    //
+                    // Notice: We read hidePassword from loginState
+                    // When user taps eye icon, state changes and this rebuilds
+                    TextFormField(
+                      controller: _passwordController,
+                      // Read hidePassword state from provider
+                      obscureText: loginState.hidePassword,
+                      validator: (value) => TValidator.validatePassword(value),
+                      onChanged: (value) {
+                        if (loginState.errorMessage != null) {
+                          ref.read(loginStateProvider.notifier).clearError();
+                        }
+                      },
+                      decoration: InputDecoration(
+                        focusedBorder: OutlineInputBorder(
+                          borderSide: BorderSide(
+                            color: dark ? TColors.light : TColors.darkGrey,
                           ),
-                          prefixIcon: const Icon(
-                            Iconsax.lock,
-                          ),
-                          // Toggle password visibility when eye icon is tapped
-                          suffixIcon: IconButton(
-                            icon: Icon(
-                              controller.hidePassword.value
-                                  ? Iconsax.eye_slash
-                                  : Iconsax.eye,
-                            ),
-                            onPressed: controller.togglePasswordVisibility,
-                          ),
-                          hintText: 'Password',
                         ),
+                        prefixIcon: const Icon(
+                          Iconsax.lock,
+                        ),
+                        // Toggle password visibility
+                        suffixIcon: IconButton(
+                          icon: Icon(
+                            loginState.hidePassword
+                                ? Iconsax.eye_slash
+                                : Iconsax.eye,
+                          ),
+                          // Call togglePasswordVisibility on notifier
+                          onPressed: () => ref
+                              .read(loginStateProvider.notifier)
+                              .togglePasswordVisibility(),
+                        ),
+                        hintText: 'Password',
                       ),
                     ),
                     const SizedBox(
@@ -150,52 +304,49 @@ class LoginScreen extends StatelessWidget {
                 height: TSizes.spaceBtwItems,
               ),
               // ============================================================
-              // STEP 3: LOGIN BUTTON WITH LOADING STATE
+              // LOGIN BUTTON WITH LOADING STATE
               // ============================================================
-              // Obx() watches controller.isLoading and rebuilds when it changes
-              Obx(
-                () => SizedBox(
-                  width: double.infinity,
-                  child: ElevatedButton(
-                    // Disable button when loading to prevent multiple submissions
-                    onPressed: controller.isLoading.value ? null : controller.login,
-                    child: controller.isLoading.value
-                        // Show loading indicator when API call is in progress
-                        ? const SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                            ),
-                          )
-                        // Show button text when not loading
-                        : const Text(TTexts.tContinue),
-                  ),
+              //
+              // The button changes based on loginState.isLoading
+              // When isLoading changes, this widget rebuilds automatically
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  // Disable button when loading
+                  onPressed: loginState.isLoading ? null : _handleLogin,
+                  child: loginState.isLoading
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor:
+                                AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        )
+                      : const Text(TTexts.tContinue),
                 ),
               ),
               const SizedBox(
                 height: TSizes.spaceBtwItems,
               ),
               // ============================================================
-              // ERROR MESSAGE DISPLAY (Optional)
+              // ERROR MESSAGE DISPLAY
               // ============================================================
-              // Shows error message if login fails
-              Obx(
-                () => controller.errorMessage.value.isNotEmpty
-                    ? Padding(
-                        padding: const EdgeInsets.only(bottom: TSizes.spaceBtwItems),
-                        child: Text(
-                          controller.errorMessage.value,
-                          style: const TextStyle(
-                            color: Colors.red,
-                            fontSize: 14,
-                          ),
-                          textAlign: TextAlign.center,
-                        ),
-                      )
-                    : const SizedBox.shrink(),
-              ),
+              //
+              // Automatically shows/hides based on state.errorMessage
+              if (loginState.errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: TSizes.spaceBtwItems),
+                  child: Text(
+                    loginState.errorMessage!,
+                    style: const TextStyle(
+                      color: Colors.red,
+                      fontSize: 14,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
@@ -228,32 +379,73 @@ class LoginScreen extends StatelessWidget {
 }
 
 /// ============================================================
-/// KEY TAKEAWAYS FROM THIS IMPLEMENTATION
+/// ALTERNATIVE: Using Consumer Widget for Specific Rebuilds
 /// ============================================================
 ///
-/// 1. CONTROLLER PATTERN:
-///    - All logic is in LoginController
-///    - UI just displays data and calls controller methods
-///    - This makes code clean and testable
+/// If you want to optimize performance and only rebuild specific parts,
+/// you can use Consumer widget:
 ///
-/// 2. REACTIVE STATE MANAGEMENT:
-///    - Obx() widget watches reactive variables (.obs)
-///    - When variable changes, only that Obx() widget rebuilds
-///    - Efficient and automatic UI updates
+/// ```dart
+/// Consumer(
+///   builder: (context, ref, child) {
+///     final isLoading = ref.watch(loginStateProvider).isLoading;
+///     return ElevatedButton(
+///       onPressed: isLoading ? null : _handleLogin,
+///       child: isLoading ? CircularProgressIndicator() : Text('Login'),
+///     );
+///   },
+/// )
+/// ```
 ///
-/// 3. FORM VALIDATION:
-///    - TextFormField with validator functions
-///    - Form key enables form.validate() in controller
-///    - Validators are reusable across the app
+/// Or even more specific with select():
 ///
-/// 4. LOADING STATES:
-///    - isLoading controls button state
-///    - Shows spinner during API call
-///    - Prevents multiple submissions
+/// ```dart
+/// final isLoading = ref.watch(
+///   loginStateProvider.select((state) => state.isLoading)
+/// );
+/// ```
 ///
-/// 5. ERROR HANDLING:
-///    - Errors shown via snackbar (in controller)
-///    - Optional error text display in UI
-///    - User gets clear feedback
+/// This way, the widget only rebuilds when isLoading changes,
+/// not when other parts of state change.
 ///
-/// This same pattern can be applied to ANY screen with API integration!
+/// ============================================================
+/// KEY RIVERPOD PATTERNS USED IN THIS FILE:
+/// ============================================================
+///
+/// 1. ConsumerStatefulWidget
+///    - Provides access to ref
+///    - Can have local state (controllers)
+///
+/// 2. ref.watch(provider)
+///    - Subscribes to provider changes
+///    - Rebuilds widget when state changes
+///    - Use in build() method
+///
+/// 3. ref.read(provider)
+///    - One-time read without listening
+///    - Use in event handlers (onPressed, etc.)
+///    - Use .notifier to call methods
+///
+/// 4. State Management Flow:
+///    User Action → ref.read().notifier.method()
+///    → Notifier updates state → ref.watch() rebuilds UI
+///
+/// ============================================================
+/// RIVERPOD vs GETX COMPARISON (THIS SCREEN):
+/// ============================================================
+///
+/// GetX:
+/// - StatelessWidget
+/// - Get.put(LoginController())
+/// - Obx(() => widget)
+/// - controller.isLoading.value
+/// - controller.login()
+///
+/// Riverpod:
+/// - ConsumerStatefulWidget
+/// - ref.watch(loginStateProvider)
+/// - No wrapper needed (direct use in build)
+/// - loginState.isLoading
+/// - ref.read(loginStateProvider.notifier).login()
+///
+/// ============================================================

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,10 @@ dependencies:
   # State Management
   get: ^4.6.5
   get_storage: ^2.1.1
+  flutter_riverpod: ^2.4.9
+
+  # HTTP Client
+  http: ^1.1.0
 
   # Product Specific
   readmore: ^2.2.0


### PR DESCRIPTION
BREAKING CHANGE: Replaced GetX controller with Riverpod StateNotifier pattern

This commit refactors the entire authentication flow to use Riverpod instead of GetX for state management, providing better type safety, testability, and maintainability.

Changes:
- Add flutter_riverpod dependency to pubspec.yaml
- Wrap app with ProviderScope in main.dart
- Create comprehensive auth_provider.dart with:
  * LoginState class for immutable state
  * LoginNotifier extending StateNotifier for business logic
  * Multiple providers (loginStateProvider, currentUserProvider, etc.)
- Refactor login_screen.dart to use ConsumerStatefulWidget
  * Replace GetX Obx() with ref.watch()
  * Replace controller.method() with ref.read().notifier.method()
  * Add detailed inline documentation explaining Riverpod concepts
- Completely rewrite API_INTEGRATION_GUIDE.md:
  * Focus on Riverpod state management
  * Explain StateNotifier pattern
  * Document ref.watch() vs ref.read()
  * Add Riverpod best practices and common pitfalls
  * Include comparison table with other state management solutions

All code is heavily commented to teach Riverpod concepts:
- What is a Provider and why use it
- StateNotifier pattern explained
- Immutable state with copyWith()
- When to use ref.watch() vs ref.read()
- Provider types and their use cases

Note: GetX is still used for navigation (Get.to, Get.offAll) as Riverpod doesn't handle navigation. This is a common and acceptable pattern.